### PR TITLE
Add scanning of multiple targets.(+ Minor improvements)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 3.1.6
+- Added scanning and brute-forcing of multiple targets
+- Scanned targets now have a summary output
+- Stop scanning if the "skip" parameter is provided
+
 ### 3.1.5
 - Fix color bug that resulted in DOM XSS vulnerabilities not
   being reported on certain systems (Windows, macOS, iOS)

--- a/core/log.py
+++ b/core/log.py
@@ -137,6 +137,12 @@ def log_red_line(self, amount=60, level='INFO'):
     _switch_to_default_loggers(self)
 
 
+def log_yellow_summary_line(self, amount=60, level='INFO'):
+    _switch_to_no_format_loggers(self)
+    _get_level_and_log(self,  f"{yellow}{'=' * amount}{end}", level)
+    _switch_to_default_loggers(self)
+
+
 def log_no_format(self, msg='', level='INFO'):
     _switch_to_no_format_loggers(self)
     _get_level_and_log(self, msg, level)
@@ -187,6 +193,8 @@ def setup_logger(name='xsstrike'):
 
     # Create logger method to only log a red line
     logger.red_line = MethodType(log_red_line, logger)
+    # Create logger method to only log a yellow line
+    logger.yellow_summary_line = MethodType(log_yellow_summary_line, logger)
     # Create logger method to log without format
     logger.no_format = MethodType(log_no_format, logger)
     # Create logger method to convert data to json and log with debug level

--- a/modes/bruteforcer.py
+++ b/modes/bruteforcer.py
@@ -34,6 +34,6 @@ def bruteforcer(target, paramData, payloadList, encoding, headers, delay, timeou
             if encoding:
                 payload = encoding(payload)
             if payload in response:
-                logger.info('%s %s' % (good, payload))
+                logger.good(payload)
             progress += 1
     logger.no_format('')

--- a/modes/scan.py
+++ b/modes/scan.py
@@ -110,8 +110,8 @@ def scan(target, paramData, encoding, headers, delay, timeout, skipDOM, skip):
                     if not skip:
                         choice = input(
                             '%s Would you like to continue scanning? [y/N] ' % que).lower()
-                        if choice != 'y':
-                            quit()
+                    if skip or choice != 'y':
+                        return target, loggerVector                       
                 elif bestEfficiency > minEfficiency:
                     logger.red_line()
                     logger.good('Payload: %s' % loggerVector)


### PR DESCRIPTION
> #### What does it implement/fix? Explain your changes.
> 
> Current PR adds an option for scanning multiple targets from a list in a simple manner.
> 
> I have added the -ul flag, which expects a path to a file with targets. Usage: python xsstrike.py -ul path/to/urls.txt --skip A target file may contain urls from a variety of sources: https://example1.com/?q=aaa https://example2com/?q=aaa https://example3.com/?q=aaa etc..
> 
> The tool displays a summary of vulnerable targets after iterating all targets.
> #### Where has this been tested?
> 
> Python Version: 3.9 Operating System: Windows 10
> #### Does this close any currently open issues?
> 
> #353
> #### Does this add any new dependency?
> 
> No
> #### Does this add any new command line switch/option?
> 
> Yes, -ul flag to provide a path to a file with targets.
> #### Any other comments you would like to make?
> 
> Great tool! Thanks for all contributors.
> #### Some Questions
> 
>     * [ *] I have documented my code. - The code is very simple and doesn't require to be documented.
> 
>     * [V ] I have tested my build before submitting the pull request. - Sure!