### PR TITLE
 Add request parameters as sources for DOM-based XSS check #286 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 3.1.6
+- Add request parameters as sources for the DOM-based XSS checker
+
 ### 3.1.5
 - Fix color bug that resulted in DOM XSS vulnerabilities not
   being reported on certain systems (Windows, macOS, iOS)

--- a/modes/scan.py
+++ b/modes/scan.py
@@ -32,19 +32,10 @@ def scan(target, paramData, encoding, headers, delay, timeout, skipDOM, find, sk
     logger.debug('Scan target: {}'.format(target))
     response = requester(target, {}, headers, GET, delay, timeout).text
 
-    if not skipDOM:
-        logger.run('Checking for DOM vulnerabilities')
-        highlighted = dom(response)
-        if highlighted:
-            logger.good('Potentially vulnerable objects found')
-            logger.red_line(level='good')
-            for line in highlighted:
-                logger.no_format(line, level='good')
-            logger.red_line(level='good')
     host = urlparse(target).netloc  # Extracts host out of the url
     logger.debug('Host to scan: {}'.format(host))
     url = getUrl(target, GET)
-    logger.debug('Url to scan: {}'.format(url))
+    logger.debug('URL to scan: {}'.format(url))
     params = getParams(target, paramData, GET)
     logger.debug_json('Scan parameters:', params)
     if find:
@@ -58,6 +49,15 @@ def scan(target, paramData, encoding, headers, delay, timeout, skipDOM, find, sk
         logger.error('WAF detected: %s%s%s' % (green, WAF, end))
     else:
         logger.good('WAF Status: %sOffline%s' % (green, end))
+    if not skipDOM:
+        logger.run('Checking for DOM vulnerabilities')
+        highlighted = dom(response, params)
+        if highlighted:
+            logger.good('Potentially vulnerable objects found')
+            logger.red_line(level='good')
+            for line in highlighted:
+                logger.no_format(line, level='good')
+            logger.red_line(level='good')
 
     for paramName in params.keys():
         paramsCopy = copy.deepcopy(params)


### PR DESCRIPTION
> #### What does it implement/fix? Explain your changes.
> 
> Currently, the DOM-based XSS checker doesn't consider request parameters as an input source. This change allows the DOM-based XSS checker to detect code injected via request parameters.
> #### Where has this been tested?
> 
> Python Version: 3.7.5 Operating System: macOS
> #### Does this close any currently open issues?
> 
> No
> #### Does this add any new dependency?
> 
> No
> #### Does this add any new command line switch/option?
> 
> No
> #### Any other comments you would like to make?
> 
> #285 should be merged first, as this change relies on it.
> #### Some Questions
> 
>     * [x]  I have documented my code.
> 
>     * [x]  I have tested my build before submitting the pull request.

