### PR TITLE
 Application can render javascript on pages that make use of javascript and include XSS vulnerabilites #334 

### DIFF
--- a/core/types.py
+++ b/core/types.py
@@ -1,0 +1,8 @@
+
+# This file is made to add new types to the project.
+
+
+# This class is used by requester function in requester.py to return only the html for use of in other functions.
+class CustomResponse: 
+    def __init__(self, html):
+        self.text = html

--- a/modes/scan.py
+++ b/modes/scan.py
@@ -11,7 +11,7 @@ from core.dom import dom
 from core.filterChecker import filterChecker
 from core.generator import generator
 from core.htmlParser import htmlParser
-from core.requester import requester, requesterJs
+from core.requester import requester
 from core.utils import getUrl, getParams, getVar
 from core.wafDetector import wafDetector
 from core.log import setup_logger

--- a/modes/scan.py
+++ b/modes/scan.py
@@ -11,7 +11,7 @@ from core.dom import dom
 from core.filterChecker import filterChecker
 from core.generator import generator
 from core.htmlParser import htmlParser
-from core.requester import requester
+from core.requester import requester, requesterJs
 from core.utils import getUrl, getParams, getVar
 from core.wafDetector import wafDetector
 from core.log import setup_logger

--- a/xsstrike.py
+++ b/xsstrike.py
@@ -79,11 +79,13 @@ parser.add_argument('--file-log-level', help='File logging level', dest='file_lo
                     choices=core.log.log_config.keys(), default=None)
 parser.add_argument('--log-file', help='Name of the file to log', dest='log_file',
                     default=core.log.log_file)
+parser.add_argument('--js', '--javascript', help='render javascript', dest='js', action='store_true')
 args = parser.parse_args()
 
 # Pull all parameter values of dict from argparse namespace into local variables of name == key
 # The following works, but the static checkers are too static ;-) locals().update(vars(args))
 target = args.target
+js = args.js
 path = args.path
 jsonData = args.jsonData
 paramData = args.paramData


### PR DESCRIPTION
> I have realized that application can't be able to scan websites that make use of javascript to render the requested query.
> #### What does it implement/fix? Explain your changes.
> 
> I have added the ability to render the javascript included in page which results in ability to scan javascript powered pages.
> #### Where has this been tested?
> 
> Python Version:3.7.3 Operating System: Debian 10
> #### Does this close any currently open issues?
> 
> #290
> #### Does this add any new dependency?
> 
> `requests_html` package
> #### Does this add any new command line switch/option?
> 
> --javascript
> #### Any other comments you would like to make?
> 
> I hope the pull request is going to be merged, inshaAllah.
> #### Some Questions
> 
>     * [+ ] I have documented my code.
> 
>     * [ +] I have tested my build before submitting the pull request.

