### PR TITLE
Support multiple blind xss payloads

### DIFF
--- a/modes/crawl.py
+++ b/modes/crawl.py
@@ -58,6 +58,12 @@ def crawl(scheme, host, main_url, form, blindXSS, blindPayload, headers, delay, 
                                     except IndexError:
                                         pass
                             if blindXSS and blindPayload:
-                                paramsCopy[paramName] = blindPayload
-                                requester(url, paramsCopy, headers,
-                                          GET, delay, timeout)
+                                if type(blindPayload) is tuple:
+                                    for x in blindPayload:
+                                        paramsCopy[paramName] = x
+                                        requester(url, paramsCopy, headers,
+                                                  GET, delay, timeout)
+                                else:
+                                    paramsCopy[paramName] = blindPayload
+                                    requester(url, paramsCopy, headers,
+                                              GET, delay, timeout)


### PR DESCRIPTION
> Currently only a single payload is supported. After this change, users can configure a single value, or a tuple with multiple values, in the configuration file.
> #### What does it implement/fix? Explain your changes.
> 
> Currently only a single payload is supported. After this change, users can configure a single value, or a tuple with multiple values, in the configuration file.
> #### Where has this been tested?
> 
> Python Version: 3.8.3 Operating System: Windows
> #### Does this close any currently open issues?
> 
> No
> #### Does this add any new dependency?
> 
> No
> #### Does this add any new command line switch/option?
> 
> No
> #### Any other comments you would like to make?
> 
> No
> #### Some Questions
> 
>     * [x]  I have documented my code.
> 
>     * [x]  I have tested my build before submitting the pull request.

