### PR TITLE
 Add option to write payloads to file #325 

### DIFF
--- a/modes/scan.py
+++ b/modes/scan.py
@@ -19,7 +19,15 @@ from core.log import setup_logger
 logger = setup_logger(__name__)
 
 
-def scan(target, paramData, encoding, headers, delay, timeout, skipDOM, find, skip):
+def write_vectors(vectors, filename):
+    with open(filename, 'w') as f:
+        for vs in vectors.values():
+            for v in vs:
+                f.write("{}\n".format(v))
+    logger.info('Written payloads to file')
+
+
+def scan(target, paramData, encoding, headers, delay, timeout, skipDOM, find, skip, payloads_file):
     GET, POST = (False, True) if paramData else (True, False)
     # If the user hasn't supplied the root url with http(s), we will handle it
     if not target.startswith('http'):
@@ -89,6 +97,8 @@ def scan(target, paramData, encoding, headers, delay, timeout, skipDOM, find, sk
             logger.error('No vectors were crafted.')
             continue
         logger.info('Payloads generated: %i' % total)
+        if payloads_file:
+            write_vectors(vectors, payloads_file)
         progress = 0
         for confidence, vects in vectors.items():
             for vect in vects:

--- a/xsstrike.py
+++ b/xsstrike.py
@@ -79,6 +79,7 @@ parser.add_argument('--file-log-level', help='File logging level', dest='file_lo
                     choices=core.log.log_config.keys(), default=None)
 parser.add_argument('--log-file', help='Name of the file to log', dest='log_file',
                     default=core.log.log_file)
+parser.add_argument('--write-payloads', dest="payloads_file", help='Write generated payloads to given file', default=None)
 args = parser.parse_args()
 
 # Pull all parameter values of dict from argparse namespace into local variables of name == key
@@ -103,6 +104,7 @@ delay = args.delay
 skip = args.skip
 skipDOM = args.skipDOM
 blindXSS = args.blindXSS
+payloads_file = args.payloads_file
 core.log.console_log_level = args.console_log_level
 core.log.file_log_level = args.file_log_level
 core.log.log_file = args.log_file
@@ -171,7 +173,7 @@ elif not recursive and not args_seeds:
     if args_file:
         bruteforcer(target, paramData, payloadList, encoding, headers, delay, timeout)
     else:
-        scan(target, paramData, encoding, headers, delay, timeout, skipDOM, find, skip)
+        scan(target, paramData, encoding, headers, delay, timeout, skipDOM, find, skip, payloads_file)
 else:
     if target:
         seedList.append(target)


### PR DESCRIPTION
> #### What does it implement/fix? Explain your changes.
> 
> It adds a parameter `--write-payloads PAYLOADS_FILE` which writes the payloads generated by `scan` to the given file. This is useful in order to run the payloads with another tool or to examine and edit them before executing.
> #### Where has this been tested?
> 
> Python Version: Python 3.9.5 Operating System: Mac OS
> 
> ```
> ProductName:	macOS
> ProductVersion:	11.4
> BuildVersion:	20F71
> ```
> 
> #### Does this close any currently open issues?
> 
> No
> #### Does this add any new dependency?
> 
> No
> #### Does this add any new command line switch/option?
> 
> Yes
> #### Any other comments you would like to make?
> #### Some Questions
> 
>     * [ ]  I have documented my code.
>       
>       * I think the changes are quite clear in itself.
> 
>     * [x]  I have tested my build before submitting the pull request.

